### PR TITLE
fix(client): create tls context and support uri via ES_URI

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: neuroplastic
-version: 1.5.0
-crystal: 0.35.0
+version: 1.6.0
+crystal: 0.35.1
 license: MIT
 
 authors:


### PR DESCRIPTION
- URI via `ES_URI` environment variable
- pass a tls context to http client